### PR TITLE
Source bashrc after adding alias for immediate availability

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,9 @@ proot-distro login debian -- bash -c '
 echo "🔗 Creating shortcuts..."
 echo 'alias pocketcode="proot-distro login debian"' >> ~/.bashrc
 
+# Step 5: Source bashrc to make alias available immediately
+source ~/.bashrc
+
 echo ""
 echo "✅ Setup Complete!"
 echo ""


### PR DESCRIPTION
Thanks for the repo. Gave it a go and it's working!
I'm doing this from my phone right now 🤓

The only thing is that the `opencode-web` alias didn't work. So this makes sure we source the RC file first to pickup the alias.

<img width="1440" height="2971" alt="Screenshot_20260106-022021" src="https://github.com/user-attachments/assets/1a4067ca-edd8-41a6-aaf3-d0a11f9f96b5" />